### PR TITLE
Fix link of posts list

### DIFF
--- a/posts.md
+++ b/posts.md
@@ -1,6 +1,7 @@
 ---
 layout: post
 title:  "記事一覧"
+permalink: /posts/
 date:   2015-12-16 15:45:47 +0900
 categories: announce update
 ---


### PR DESCRIPTION
I can't access(404) to 'https://oss-gate.github.io/posts/' but I can to 'https://oss-gate.github.io/posts'

I don't know well about jekyll, but it should be necessary to setup for resolving 404