### PR TITLE
Adjust .home-header layout

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -7,10 +7,7 @@
 
 <div class="home-header">
   <div class="wrapper">
-    <img
-      src="{{ site.baseurl }}/images/logo.png"
-      align="left"
-      style="margin-right:30px;"
+    <img src="{{ site.baseurl }}/images/logo.png"
     />
     <h1>{{ site.title }}</h1>
     <p>{{ site.description }}</p>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -255,6 +255,19 @@
     background-image: url('../images/bg.png');
     color: white;
     padding: 30px;
+
+    img {
+        float: left;
+        margin-right: 30px;
+    }
+
+    @include media-query($on-laptop) {
+        img {
+            display: block;
+            float: unset;
+            margin: 0 auto 30px;
+        }
+    }
 }
 
 .home-point {


### PR DESCRIPTION
なにをしたのか
---

$on-laptop(800px)の幅になったらOSS Gateのロゴを中心に配置するようにした

なんでしたのか
---

ロゴに対するテキストのまわり込みが発生すると、テキストを読みにくくなると感じたため

変更前
---

![image](https://user-images.githubusercontent.com/9744580/52056087-9f5c4780-25a4-11e9-8fd6-0f33c78909d7.png)

変更後
---

![image](https://user-images.githubusercontent.com/9744580/52056119-b307ae00-25a4-11e9-8ab2-0d153f9468b5.png)
