### PR TITLE
Fix 404 links to gitter.im

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,7 +24,7 @@
           </li>
           {% endif %}
           <li><a href="https://oss-gate.doorkeeper.jp/">Doorkeeper</a></li>
-          <li><a href="https://gitter.im/oss-gate/general/">Gitter</a></li>
+          <li><a href="https://gitter.im/oss-gate/general">Gitter</a></li>
           <li><a href="https://www.youtube.com/channel/UCko4k40eSvs_dchzcLCsJ4A">YouTube</a></li>
 
           {% if site.twitter_username %}

--- a/_posts/2018-05-17-workshop-hostting.md
+++ b/_posts/2018-05-17-workshop-hostting.md
@@ -13,7 +13,7 @@ OSS開発に参加する「入り口」を提供する**OSS Gate**は、OSS開�
 - [ワークショップレポートを読む](https://oss-gate.github.io/workshop/report.html)
 - [OSS Gateについて](https://oss-gate.github.io/about/)
 
-興味があれば、[Gitter - oss-gate/general](https://gitter.im/oss-gate/general/)で、相談してみてください。
+興味があれば、[Gitter - oss-gate/general](https://gitter.im/oss-gate/general)で、相談してみてください。
 
 
 ## OSS Gateの主な活動形式
@@ -27,7 +27,7 @@ OSS開発に参加する「入り口」を提供する**OSS Gate**は、OSS開�
 
 ## 開催手順
 
-1. [Gitter - oss-gate/general](https://gitter.im/oss-gate/general/)で、開催について相談・意思表示する
+1. [Gitter - oss-gate/general](https://gitter.im/oss-gate/general)で、開催について相談・意思表示する
 2. 日時・場所を調整する
 3. [Doorkeeper](https://oss-gate.doorkeeper.jp/)で告知する(DoorKeeperで主催者となっているメンバーに相談する)
 4. 開催する
@@ -61,7 +61,7 @@ OSS開発に参加する「入り口」を提供する**OSS Gate**は、OSS開�
 
 サポーター数 >= ビギナー数 / 2 が、1つの目安になると思います。
 
-サポーターが十分に集まらない場合、[Gitter - oss-gate/general](https://gitter.im/oss-gate/general/)で相談してもらうと、お手伝いできる人が見つかるかも知れません。
+サポーターが十分に集まらない場合、[Gitter - oss-gate/general](https://gitter.im/oss-gate/general)で相談してもらうと、お手伝いできる人が見つかるかも知れません。
 
 
 ### ワークショップには、どのくらいの時間がかかりますか
@@ -110,4 +110,4 @@ OSS開発に参加する「入り口」を提供する**OSS Gate**は、OSS開�
 
 ### この他に、質問や問い合わせ・フィードバックをしたい場合、どうすれば良いですか
 
-[oss-gate/general - Gitter](https://gitter.im/oss-gate/general/)で、相談してみてください。不足している情報があるかも知れないので、フィードバックをもらえるとありがたいです。
+[oss-gate/general - Gitter](https://gitter.im/oss-gate/general)で、相談してみてください。不足している情報があるかも知れないので、フィードバックをもらえるとありがたいです。

--- a/about.md
+++ b/about.md
@@ -17,7 +17,7 @@ permalink: /about/
 - ワークショップの様子や内容を知りたい：[ワークショップレポート]({{ site.baseurl }}/workshop/report.html)を読んでみてください。
 - ワークショップにビギナーとして参加したい：[Doorkeeper](https://oss-gate.doorkeeper.jp/)でビギナーとして申し込んでください。
 - ワークショップをサポーターとして手伝いたい：[Doorkeeper](https://oss-gate.doorkeeper.jp/)でサポーターとして申し込んでください。
-- OSS Gateの活動を手伝いたい、サポーター以外の方法で支援したい場合：[Gitter](https://gitter.im/oss-gate/general/)で聞いてみてください。
+- OSS Gateの活動を手伝いたい、サポーター以外の方法で支援したい場合：[Gitter](https://gitter.im/oss-gate/general)で聞いてみてください。
 
 
 ## OSS Gateを始めた理由


### PR DESCRIPTION
The gitter.im URL that has a trailing slash is now 404:

- OK: https://gitter.im/oss-gate/general
- NG: https://gitter.im/oss-gate/general/