### PR TITLE
Add '参加者による OSS 開発実績' section

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,51 @@ layout: home
   </div>
 
   <hr class="home-point-line" />
+
+  <div class="home-point footer-col-wrapper">
+    <h2 class="home-point-heading">参加者による OSS 開発実績</h2>
+    <p class="home-point-text">
+      初めての方も、OSS Gate で学び、様々な OSS に貢献しています。
+    </p>
+    <ul style='list-style: none;'>
+      <li>
+	<a class="post-link" href="https://github.com/rails/rails/pull/50756" target="_blank">
+	  Ruby on Rails
+	  <span style='font-size: small;'>(rails/rails#5056)</span>
+	</a>
+      </li>
+      <li>
+	<a class="post-link" href="https://github.com/konvajs/konva/pull/1646" target="_blank">
+	  Konva.js
+	  <span style='font-size: small;'>(konvajs/konva#1646)</span>
+	</a>
+      </li>
+      <li>
+	<a class="post-link" href="https://github.com/yui-knk/lr-parser-101/pull/2" target="_blank">
+	  LR parser 101
+	  <span style='font-size: small;'>(yui-knk/lr-parser-101#2)</span>
+	</a>
+      </li>
+      <li>
+	<a class="post-link" href="https://github.com/picoruby/prk_firmware-wiki/pull/15" target="_blank">
+	  PicoRuby
+	  <span style='font-size: small;'>(picoruby/prk_firmware-wiki#15)</span>
+	</a>
+      </li>
+      <li>
+	<a class="post-link" href="https://github.com/DavidAnson/vscode-markdownlint/pull/299" target="_blank">
+	  markdownlint
+	  <span style='font-size: small;'>(DavidAnson/vscode-markdownlint#299)</span>
+	</a>
+      </li>
+    </ul>
+
+    <p class="home-point-caption" style='padding-top: 30px;'>
+      <a href="/workshop/report.html">&#8811; 他の開発実績・参加レポートを見る</a>
+    </p>
+  </div>
+
+  <hr class="home-point-line" />
   <h2 class="page-heading" id="workshop">ワークショップ</h2>
 
   <ul>


### PR DESCRIPTION
Fix #118 

> - プルリクを送れたor送れそうな事例はいくつかありそうなので、そういった事例を集め、OSS Gate のWebサイトから活動事例として紹介する
>   - OSS Gate の価値を具体例と共に紹介することで、**参加者側からすれば「こういうことが自分もできるかもしれない！」というイメージを掴みやすく**なったり、**主催者側からすれば「こんなに価値があるならウチでも OSS Gate 開催しよう」** という話が持ち上がるかもしれない 😌💭


@kou 「参加者による OSS 開発実績」のセクションを追加しました! 📝 ✨ 

## 左: パソコン版 💻、右: スマホ版 📱 

![oss-gate-achievements](https://github.com/oss-gate/oss-gate.github.io/assets/155807/f68a1f45-dda8-460d-95d4-ffce97ba1c74)

## 考えたこと

- なるべく文字数は少なめに（src: [Don't Make Me Think](https://note.com/nokowashiyama/n/n08805edf7475)）
- YAML化は後回し（もっと良い見せ方があるかも? [早すぎる最適化](https://speakerdeck.com/yasslab/why-i-am-sticking-with-rails?slide=19)対策）
- すべては載せず、いくつかをハイライトして、[レポートページ](https://oss-gate.github.io/workshop/report.html)への導線を貼る
  - ハイライトするPRも、なるべく色んな種類があることを示唆する事例にした: `Ruby`, `JavaScript`, `Parser (低レイヤー枠)`, `firmware (組み込み枠)`, `Visual Studio Code`